### PR TITLE
Update internal state when props change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,16 @@ class TimePicker extends Component {
     this.state = { selectedHour, selectedMinute };
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    const { selectedHour, selectedMinute } = this.props;
+    if (selectedHour !== prevState.selectedHour || selectedMinute !== prevState.selectedMinute) {
+      this.setState({
+        selectedHour,
+        selectedMinute
+      })
+    }
+  }
+
   getHourItems = () => {
     const items = [];
     const { maxHour, hourInterval, hourUnit } = this.props;


### PR DESCRIPTION
Hey there!

While trying to use this TimePicker in our app, the TimePicker would not update the selectedHour and selectedMinute values after the initial props are passed unless onConfirm and onCancel are called. This means that if you try to update the selectedHour and selectedMinute, the new props would be ignored. 

I fixed this issue by adding componentDidUpdate (check the commit).

Thanks!