### PR TITLE
Added functionality for a minium hour prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import { StyleProp, ViewStyle } from "react-native";
 declare module "react-native-24h-timepicker" {
   export type TimePickerProps = {
     maxHour?: number;
+    minHour?: number;
     maxMinute?: number;
     hourInterval?: number;
     minuteInterval?: number;

--- a/package.json
+++ b/package.json
@@ -1,16 +1,46 @@
 {
-  "name": "react-native-24h-timepicker",
-  "version": "1.1.0",
+  "_args": [
+    [
+      "react-native-24h-timepicker@1.1.0",
+      "/Users/thomasstansel/Documents/GitHub/monitoring-mobile-app"
+    ]
+  ],
+  "_from": "react-native-24h-timepicker@1.1.0",
+  "_id": "react-native-24h-timepicker@1.1.0",
+  "_inBundle": false,
+  "_integrity": "sha512-rnOHWmKcSbbdpYBVl2MxkQY7IU83f/5K6NB8iq4nmWdq8WfHklnkfvfpjnga8uY6sqLDAK11j+dQHo0XVK+QIg==",
+  "_location": "/react-native-24h-timepicker",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "version",
+    "registry": true,
+    "raw": "react-native-24h-timepicker@1.1.0",
+    "name": "react-native-24h-timepicker",
+    "escapedName": "react-native-24h-timepicker",
+    "rawSpec": "1.1.0",
+    "saveSpec": null,
+    "fetchSpec": "1.1.0"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/react-native-24h-timepicker/-/react-native-24h-timepicker-1.1.0.tgz",
+  "_spec": "1.1.0",
+  "_where": "/Users/thomasstansel/Documents/GitHub/monitoring-mobile-app",
+  "author": {
+    "name": "NY Samnang"
+  },
+  "bugs": {
+    "url": "https://github.com/NYSamnang/react-native-24h-timepicker/issues"
+  },
+  "dependencies": {
+    "react-native-raw-bottom-sheet": "^1.0.0"
+  },
   "description": "React Native 24 hours format TimePicker for iOS",
-  "main": "index.js",
-  "typings": "index.d.ts",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "devDependencies": {
+    "prop-types": "^15.7.2"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/NYSamnang/react-native-24h-timepicker.git"
-  },
+  "homepage": "https://github.com/NYSamnang/react-native-24h-timepicker#readme",
   "keywords": [
     "react-native",
     "24 hour format",
@@ -18,16 +48,16 @@
     "time picker ios",
     "number picker ios"
   ],
-  "author": "NY Samnang",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/NYSamnang/react-native-24h-timepicker/issues"
+  "main": "index.js",
+  "name": "react-native-24h-timepicker",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NYSamnang/react-native-24h-timepicker.git"
   },
-  "homepage": "https://github.com/NYSamnang/react-native-24h-timepicker#readme",
-  "dependencies": {
-    "react-native-raw-bottom-sheet": "^1.0.0"
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "devDependencies": {
-    "prop-types": "^15.7.2"
-  }
+  "typings": "index.d.ts",
+  "version": "1.1.0"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,10 @@ class TimePicker extends Component {
 
   getHourItems = () => {
     const items = [];
-    const { maxHour, hourInterval, hourUnit } = this.props;
+    const { minHour, maxHour, hourInterval, hourUnit } = this.props;
     const interval = maxHour / hourInterval;
-    for (let i = 0; i <= interval; i++) {
+
+    for (let i = minHour; i <= interval; i++) {
       const value = `${i * hourInterval}`;
       const item = (
         <Picker.Item key={value} value={value} label={value + hourUnit} />
@@ -37,7 +38,7 @@ class TimePicker extends Component {
 
   getMinuteItems = () => {
     const items = [];
-    const { maxMinute, minuteInterval, minuteUnit } = this.props;
+    const {maxMinute, minuteInterval, minuteUnit } = this.props;
     const interval = maxMinute / minuteInterval;
     for (let i = 0; i <= interval; i++) {
       const value = i * minuteInterval;
@@ -77,6 +78,9 @@ class TimePicker extends Component {
   };
 
   open = () => {
+
+    TimePicker.defaultProps.selectedHour = this.props.minHour.toString(10);
+    this.props.selectedHour = this.props.minHour.toString(10);
     this.RBSheet.open();
   };
 
@@ -141,6 +145,7 @@ class TimePicker extends Component {
 
 TimePicker.propTypes = {
   maxHour: PropTypes.number,
+  minHour: PropTypes.number,
   maxMinute: PropTypes.number,
   hourInterval: PropTypes.number,
   minuteInterval: PropTypes.number,
@@ -157,6 +162,7 @@ TimePicker.propTypes = {
 
 TimePicker.defaultProps = {
   maxHour: 23,
+  minHour: 0,
   maxMinute: 59,
   hourInterval: 1,
   minuteInterval: 1,


### PR DESCRIPTION
Added in the minHour Prop. 

Upon opening the TimePicker the selectedHour prop is set to minHour for the case when the user opens the TimePicker, does not change a the value and hits done. It will return the minHour rather than 0:00. 

Closes #7 