### PR TITLE
React Native Picker import updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/NYSamnang/react-native-24h-timepicker#readme",
   "dependencies": {
-    "react-native-raw-bottom-sheet": "^1.0.0"
+    "react-native-raw-bottom-sheet": "^1.0.0",
+    "@react-native-picker/picker": "^2.4.8"
   },
   "devDependencies": {
     "prop-types": "^15.7.2"

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { View, TouchableOpacity, Text, Picker } from "react-native";
+import { View, TouchableOpacity, Text } from "react-native";
 import RBSheet from "react-native-raw-bottom-sheet";
 import styles from "./styles";
+import {Picker} from '@react-native-picker/picker';
 
 class TimePicker extends Component {
   constructor(props) {


### PR DESCRIPTION
Since the new version of react native we need to import the Picker object in a different way